### PR TITLE
Fix typos

### DIFF
--- a/archive/md/0920.md
+++ b/archive/md/0920.md
@@ -1,19 +1,19 @@
-## 920: Using multiple cores for faster analisys?
+## 920: Using multiple cores for faster analysis?
 
-- Title: 920: Using multiple cores for faster analisys?
+- Title: 920: Using multiple cores for faster analysis?
 - Author: rnakamurawatanabe
 - Date: Apr 13 10:14 AM
 
 ```
-Hi everyone.I'am estimating (co)variances components and breeding values using THRGIBBS1F90 and GIBBS2F90.The data that
+Hi everyone. I'am estimating (co)variances components and breeding values using THRGIBBS1F90 and GIBBS2F90.The data that
 I have contains more than 150.000 animals on pedigree, 70.000 observations for phenotype and 8.000 animals with genomic
-information (350.000 SNPs per animal).As you can see, my analisys is tooking too much time to finish (1 month with 8
-traits analisys, with genomic information, using THRGIBBS1F90).I'am running the BLUP familiy programs on a server that
-have 32 cores (Intel Xeon E5-2630 2.4Ghz; 25GB RAM), but when I do a "htop", I can see that every analisys that I run
+information (350.000 SNPs per animal).As you can see, my analysis is taking too much time to finish (1 month with 8
+traits analysis, with genomic information, using THRGIBBS1F90). I'am running the BLUP family programs on a server that
+have 32 cores (Intel Xeon E5-2630 2.4Ghz; 25GB RAM), but when I do a "htop", I can see that every analysis that I run
 only uses 1 core of the processor.Is there anyway that I can use multiple-cores when running THRGIBBS1F90?Or other
-solutions to run faster analisys?Thanks!
+solutions to run faster analysis?Thanks!
 ```
 
-- [920](0920.md): Using multiple cores for faster analisys? by rnakamurawatanabe, Apr 13 10:14 AM
-    - [922](0922.md): Re: Using multiple cores for faster analisys? by yutakamasuda, Apr 17 9:33 AM
-        - [923](0923.md): Re: Using multiple cores for faster analisys? by rnakamurawatanabe, Apr 17 11:10 AM
+- [920](0920.md): Using multiple cores for faster analysis? by rnakamurawatanabe, Apr 13 10:14 AM
+    - [922](0922.md): Re: Using multiple cores for faster analysis? by yutakamasuda, Apr 17 9:33 AM
+        - [923](0923.md): Re: Using multiple cores for faster analysis? by rnakamurawatanabe, Apr 17 11:10 AM


### PR DESCRIPTION
See diff ;-) This was a from a GitHub workflow demo. We simply searched for some markdown file with the typo "analisys". Apologies if this caused you any unwelcome disruption.